### PR TITLE
This is useful as you may want to run as root but share non-root $HOME

### DIFF
--- a/podman-ollama
+++ b/podman-ollama
@@ -21,14 +21,18 @@ cleanup() {
 check_root() {
   if [ "$EUID" -eq 0 ]; then
     if ! $ROOT; then
-      echo "to run as a rootful, insecure container, use this command as root user:"
+      echo "to run as a rootful, insecure container, use this command:"
       echo "  podman-ollama -r"
       exit 3
     fi
   elif $ROOT; then
-    echo "to run as a rootful, insecure container, use this command as root user:"
-    echo "  podman-ollama -r"
-    exit 4
+    if command -v sudo > /dev/null; then
+      SUDO="sudo"
+    else
+      echo "to run as a rootful, insecure container, use this command as root user:"
+      echo "  podman-ollama -r"
+      exit 4
+    fi
   fi
 }
 


### PR DESCRIPTION
If you require rootful containers to be run as root user without sudo, you cannot use non-root $HOME.