### PR TITLE
Rootless privileged only

### DIFF
--- a/podman-ollama
+++ b/podman-ollama
@@ -18,7 +18,14 @@ server_init() {
 
   VOL="ollama:/root/.ollama"
   URL="docker.io/ollama/ollama:$POST"
-  PRIV="--privileged"
+
+  # This was introduced as part of ChromeOS support, but there was concerns
+  # raised about rootful privileged containers, lets just do this in the rootless
+  # case for now.
+  if [ "$EUID" -ne 0 ]; then
+    PRIV="--privileged"
+  fi
+
   GPU="--gpus=all"
   CON_PS=$($PRE $CON run --rm $PRIV -d $ADD $GPU -v"$HOME":"$HOME" -v$VOL $URL)
   RET="$?"


### PR DESCRIPTION
This was introduced as part of ChromeOS support, but there was concerns raised about rootful privileged containers, lets just do this in the rootless case for now.